### PR TITLE
procid fix in  logstash 6.3.1

### DIFF
--- a/logstash/synesis_lite_syslog/conf.d/20_filter.logstash.conf
+++ b/logstash/synesis_lite_syslog/conf.d/20_filter.logstash.conf
@@ -11,6 +11,13 @@ filter {
       "message" => "[event][message]"
       "type" => "[event][type]"
     }
+    
+    ## In logstash 6.3.1
+    ## Do you get this error? : "error"=>{"type"=>"mapper_parsing_exception", "reason"=>"failed to parse [procid]", "caused_by"=>{"type"=>"illegal_argument_exception", "reason"=>"For input string: \"-\""}}
+    ## There is an issue with procid... It is expected to be type long but it is string
+    ## One fix would be to: convert => { "procid" => "string" }  but it did not work for me so I removed the field from feed:
+    remove_field => [ "procid"]
+    
   }
 
   # Syslog messages can come in various basic formats. Here we check for common patterns and extract the basic fields as well as the logged message.


### PR DESCRIPTION
In logstash 6.3.1 do you get this error?
 "error"=>{"type"=>"mapper_parsing_exception", "reason"=>"failed to parse [procid]", "caused_by"=>{"type"=>"illegal_argument_exception", "reason"=>"For input string: \"-\""}}

There is an issue with procid... It is expected to be type long but it is string
One fix would be to: convert => { "procid" => "string" }  but it did not work for me so I removed the field from feed:
 remove_field => [ "procid"]